### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,3 @@ updates:
     interval: weekly
     day: monday
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: pyiron-base
-    versions:
-    - 0.2.11


### PR DESCRIPTION
The dependabot config has
```
  ignore:
  - dependency-name: pyiron-base
    versions:
    - 0.2.11
```
on it and I actually do not know the reason for that. @muh-hassani was this on purpose?
Might close #60