### PR TITLE
Use state instead of Settings

### DIFF
--- a/pyiron_continuum/elasticity/eschelby.py
+++ b/pyiron_continuum/elasticity/eschelby.py
@@ -3,7 +3,6 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import numpy as np
-from pyiron_base import Settings
 
 __author__ = "Sam Waseda"
 __copyright__ = "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH " \
@@ -13,8 +12,6 @@ __maintainer__ = "Sam Waseda"
 __email__ = "waseda@mpie.de"
 __status__ = "development"
 __date__ = "Aug 21, 2021"
-
-s = Settings()
 
 
 class Eschelby:

--- a/pyiron_continuum/elasticity/green.py
+++ b/pyiron_continuum/elasticity/green.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 from pyiron_continuum.elasticity import tools
-from pyiron_base import Settings
 
 __author__ = "Sam Waseda"
 __copyright__ = "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH " \
@@ -14,8 +13,6 @@ __maintainer__ = "Sam Waseda"
 __email__ = "waseda@mpie.de"
 __status__ = "development"
 __date__ = "Aug 21, 2021"
-
-s = Settings()
 
 
 class Green:

--- a/pyiron_continuum/elasticity/linear_elasticity.py
+++ b/pyiron_continuum/elasticity/linear_elasticity.py
@@ -3,7 +3,6 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import numpy as np
-from pyiron_base import Settings
 from pyiron_continuum.elasticity.green import Anisotropic, Isotropic, Green
 from pyiron_continuum.elasticity.eschelby import Eschelby
 from pyiron_continuum.elasticity import tools
@@ -16,8 +15,6 @@ __maintainer__ = "Sam Waseda"
 __email__ = "waseda@mpie.de"
 __status__ = "development"
 __date__ = "Aug 21, 2021"
-
-s = Settings()
 
 
 def value_or_none(func):

--- a/pyiron_continuum/project.py
+++ b/pyiron_continuum/project.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function
 # import warnings
-from pyiron_base import Settings, JobTypeChoice, Project as ProjectCore
+from pyiron_base import JobTypeChoice, Project as ProjectCore
 from pyiron_base import Creator as CreatorCore, PyironFactory, ImportAlarm
 from pyiron_continuum.elasticity.linear_elasticity import LinearElasticity
 with ImportAlarm(
@@ -30,8 +30,6 @@ __maintainer__ = "Jan Janssen"
 __email__ = "janssen@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"
-
-s = Settings()
 
 
 class Damask(PyironFactory):


### PR DESCRIPTION
A surprising amount of the time that just meant getting rid of the Settings import, as it was unused. I also snuck in a couple other unused import removals and some encoding info additions here and there, depending on the repo.