### PR TITLE
Make safer parsing of d5Out

### DIFF
--- a/pyiron_continuum/damask/regrid.py
+++ b/pyiron_continuum/damask/regrid.py
@@ -35,7 +35,8 @@ class Regrid:
     @cached_property
     def d5Out(self):
         d5Out = damask.Result(self.load_name)
-        d5Out = d5Out.view(increments=int(d5Out.increments[-1]))
+        increments = int(d5Out.increments[-1].split("_")[-1])
+        d5Out = d5Out.view(increments=increments)
         return d5Out
 
     @property


### PR DESCRIPTION
This fix (?) addresses the problem encountered [here](https://github.com/pyiron/pyiron_continuum/pull/318), even though I don't really understand why it's raising an error in the first place.