### PR TITLE
Restructure damask input

### DIFF
--- a/pyiron_continuum/damask/factory.py
+++ b/pyiron_continuum/damask/factory.py
@@ -11,7 +11,7 @@ with ImportAlarm(
     from damask import GeomGrid, YAML, ConfigMaterial, seeds, Rotation
 import numpy as np
 from pyiron_continuum.reference.mendeleev import get_atom_info
-from pyiron_continuum.reference.yaml import get_elasticity, get_plasticity
+from pyiron_continuum.damask.reference.yaml import get_elasticity, get_plasticity
 
 __author__ = "Muhammad Hassani"
 __copyright__ = (
@@ -255,7 +255,7 @@ class Create:
 
     @staticmethod
     def list_plasticity():
-        return get_elasticity()
+        return get_plasticity()
 
     @staticmethod
     def plasticity(**kwargs):

--- a/pyiron_continuum/damask/factory.py
+++ b/pyiron_continuum/damask/factory.py
@@ -11,6 +11,7 @@ with ImportAlarm(
     from damask import GeomGrid, YAML, ConfigMaterial, seeds, Rotation
 import numpy as np
 from pyiron_continuum.reference.mendeleev import get_atom_info
+from pyiron_continuum.reference.yaml import get_elasticity, get_plasticity
 
 __author__ = "Muhammad Hassani"
 __copyright__ = (
@@ -233,6 +234,10 @@ class Create:
         return d
 
     @staticmethod
+    def list_elasticity():
+        return get_elasticity()
+
+    @staticmethod
     def elasticity(**kwargs):
         """
         Args:
@@ -247,6 +252,10 @@ class Create:
             )
         """
         return kwargs
+
+    @staticmethod
+    def list_plasticity():
+        return get_elasticity()
 
     @staticmethod
     def plasticity(**kwargs):

--- a/pyiron_continuum/toolkit.py
+++ b/pyiron_continuum/toolkit.py
@@ -141,6 +141,13 @@ class DAMASK:
         return DAMASKCreator.elasticity(**kwargs)
 
     @staticmethod
+    def list_elasticity():
+        """
+        returns a list of available elasticity types
+        """
+        return DAMASKCreator.list_elasticity()
+
+    @staticmethod
     def Plasticity(**kwargs):
         """
         returns a dictionary of plasticity parameters for damask input file
@@ -154,6 +161,13 @@ class DAMASK:
                                     xi_inf_sl=[63e6])
         """
         return DAMASKCreator.plasticity(**kwargs)
+
+    @staticmethod
+    def list_plasticity():
+        """
+        returns a list of available plasticity types
+        """
+        return DAMASKCreator.list_plasticity()
 
     @staticmethod
     def Rotation(method="from_random", *args, **kwargs):


### PR DESCRIPTION
Now I included the listing of the elasticity and plasticity parameters from the database in the creator on the project level. Here's the difference:

Before:
```python
elasticity = job.create.elasticity(type= 'Hooke', C_11= 106.75e9,
                                   C_12= 60.41e9, C_44=28.34e9)

plasticity = job.create.plasticity(N_sl=[12], a_sl=2.25, 
                                   atol_xi=1.0, dot_gamma_0_sl=0.001,
                                   h_0_sl_sl=75e6, h_sl_sl=[1, 1, 1.4, 1.4, 1.4, 1.4],
                                   n_sl=20, output=['xi_sl'], type='phenopowerlaw',
                                   xi_0_sl=[31e6], xi_inf_sl=[63e6])
```

Now:
```python
elasticity_list = pr.continuum.damask.list_elasticity()
elasticity = pr.continuum.damask.Elasticity(**elasticity_list["Hooke_Al"])

plasticity_list = pr.continuum.damask.list_plasticity()
plasticity = pr.continuum.damask.Plasticity(**plasticity_list["phenopowerlaw_Al"])
```

Obviously you can still use the previous syntax **and** quite crucially you can also change the parameters before inserting them into `Plasticity`, since `plasticity_list["phenopowerlaw_Al"]` is only a dictionary of parameters.