### PR TITLE
Make homogenization optional

### DIFF
--- a/pyiron_continuum/damask/factory.py
+++ b/pyiron_continuum/damask/factory.py
@@ -182,7 +182,7 @@ class Create:
         return MaterialFactory.config(rotation, elements, phase, homogenization)
 
     @staticmethod
-    def homogenization(method, parameters):
+    def homogenization(method=None, parameters=None):
         """
         Returns damask homogenization as a dictionary.
         Args:
@@ -191,6 +191,10 @@ class Create:
         Examples:
             homogenization(method='SX', parameters={'N_constituents': 1, "mechanical": {"type": "pass"}})
         """
+        if method is None:
+            method = "SX"
+        if parameters is None:
+            parameters = {"N_constituents": 1, "mechanical": {"type": "pass"}}
         return {method: parameters}
 
     @staticmethod

--- a/pyiron_continuum/project.py
+++ b/pyiron_continuum/project.py
@@ -83,7 +83,7 @@ class Damask(PyironFactory):
         return DAMASKCreator.plasticity(**kwargs)
 
     @staticmethod
-    def homogenization(method, parameters):
+    def homogenization(method=None, parameters=None):
         warnings.warn(
             "Setting homogenization via project creator is deprecated. Use job.set_homogenization instead"
         )

--- a/pyiron_continuum/toolkit.py
+++ b/pyiron_continuum/toolkit.py
@@ -87,7 +87,7 @@ class DAMASK:
         return DAMASKCreator.material(rotation, elements, phase, homogenization)
 
     @staticmethod
-    def Homogenization(method, parameters):
+    def Homogenization(method=None, parameters=None):
         """
         returns damask homogenization as a dictionary
         Args:


### PR DESCRIPTION
Since `homogenisation` always has the same arguments, I made them optional.

Before:
```python
homogenization = pr.continuum.damask.Homogenization(method='SX', 
                                                     parameters={'N_constituents': 1,
                                                                 "mechanical": {"type": "pass"}})
```


Now:
```python
homogenization = pr.continuum.damask.Homogenization()
```

And as always, you can still use the earlier commands.