### PR TITLE
Abstract loading

### DIFF
--- a/pyiron_continuum/damask/damaskjob.py
+++ b/pyiron_continuum/damask/damaskjob.py
@@ -247,16 +247,19 @@ class DAMASK(TemplateJob):
     def append_loading(self, load_steps):
         if not isinstance(load_steps, list):
             load_steps = [load_steps]
-        self.input.loading["loadstep"].extend(
-            [
-                translate_load_steps(
-                    mech_bc_dict=load_step["mech_bc_dict"],
-                    discretization=load_step["discretization"],
-                    additional_parameters_dict=load_step["additional"],
-                )
-                for load_step in load_steps
-            ]
-        )
+        if "mech_bc_dict" in load_steps[0]:
+            self.input.loading["loadstep"].extend(
+                [
+                    translate_load_steps(
+                        mech_bc_dict=load_step["mech_bc_dict"],
+                        discretization=load_step["discretization"],
+                        additional_parameters_dict=load_step["additional"],
+                    )
+                    for load_step in load_steps
+                ]
+            )
+        else:
+            self.input.loading["loadstep"].extend(load_steps)
 
     def _write_material(self):
         if self.input.material is not None:

--- a/pyiron_continuum/damask/factory.py
+++ b/pyiron_continuum/damask/factory.py
@@ -95,10 +95,21 @@ class GridFactory:
 
 
 def generate_loading_tensor():
+    """
+    Returns the default boundary conditions for the damask loading tensor.
+    """
     return np.full((3, 3), "F").astype("<U5"), np.eye(3)
 
 
-def generate_load_step(boundary_conditions, N, t, f_out=None, r=None, f_restart=None, estimate_rate=None):
+def generate_load_step(
+    boundary_conditions,
+    N,
+    t,
+    f_out=None,
+    r=None,
+    f_restart=None,
+    estimate_rate=None
+):
     """
     Args:
         boundary_conditions (tuple[list, list]): Keys and values of the

--- a/pyiron_continuum/damask/factory.py
+++ b/pyiron_continuum/damask/factory.py
@@ -178,19 +178,18 @@ class DamaskLoading(dict):
         super(DamaskLoading, self).__init__(self)
 
     def __new__(cls, solver, load_steps):
-        loading_dict = dict()
-        loading_dict["solver"] = solver
         if not isinstance(load_steps, list):
             load_steps = [load_steps]
-        loading_dict["loadstep"] = [
-            LoadStep(
-                mech_bc_dict=load_step["mech_bc_dict"],
-                discretization=load_step["discretization"],
-                additional_parameters_dict=load_step["additional"],
-            )
-            for load_step in load_steps
-        ]
-        return YAML(solver=loading_dict["solver"], loadstep=loading_dict["loadstep"])
+        if "mech_bc_dict" in load_steps[0]:
+            load_steps = [
+                LoadStep(
+                    mech_bc_dict=load_step["mech_bc_dict"],
+                    discretization=load_step["discretization"],
+                    additional_parameters_dict=load_step["additional"],
+                )
+                for load_step in load_steps
+            ]
+        return YAML(solver=solver, loadstep=load_steps)
 
 
 class LoadStep(dict):

--- a/pyiron_continuum/damask/factory.py
+++ b/pyiron_continuum/damask/factory.py
@@ -138,7 +138,7 @@ class LoadStep(dict):
 
     @staticmethod
     def load_tensorial(arr):
-        return [arr[0:3], arr[3:6], arr[6:9]]
+        return np.asarray(arr).reshape(3, 3).tolist()
 
 
 class Create:

--- a/pyiron_continuum/damask/factory.py
+++ b/pyiron_continuum/damask/factory.py
@@ -126,9 +126,7 @@ class LoadStep(dict):
             }
         )
 
-        if additional_parameters_dict is not None and isinstance(
-            additional_parameters_dict, dict
-        ):
+        if isinstance(additional_parameters_dict, dict):
             self.update(additional_parameters_dict)
 
         for key, val in mech_bc_dict.items():

--- a/pyiron_continuum/damask/factory.py
+++ b/pyiron_continuum/damask/factory.py
@@ -260,6 +260,46 @@ class Create:
         self._grid = value
 
     @staticmethod
+    def generate_loading_tensor(default="F"):
+        return generate_loading_tensor(default=default)
+
+    generate_loading_tensor.__doc__ = generate_loading_tensor.__doc__
+
+    @staticmethod
+    def loading_tensor_to_dict(key, value):
+        return loading_tensor_to_dict(key, value)
+
+    loading_tensor_to_dict.__doc__ = loading_tensor_to_dict.__doc__
+
+    @staticmethod
+    def generate_load_step(
+        N,
+        t,
+        F=None,
+        dot_F=None,
+        P=None,
+        dot_P=None,
+        f_out=None,
+        r=None,
+        f_restart=None,
+        estimate_rate=None,
+    ):
+        return generate_load_step(
+            N=N,
+            t=t,
+            F=F,
+            dot_F=dot_F,
+            P=P,
+            dot_P=dot_P,
+            f_out=f_out,
+            r=r,
+            f_restart=f_restart,
+            estimate_rate=estimate_rate,
+        )
+
+    generate_load_step.__doc__ = generate_load_step.__doc__
+
+    @staticmethod
     def loading(solver, load_steps):
         """
         Creates the required damask loading.

--- a/pyiron_continuum/damask/factory.py
+++ b/pyiron_continuum/damask/factory.py
@@ -189,6 +189,9 @@ def generate_load_step(
 
     Returns:
         dict: A dictionary of the load step
+
+    You can find more information about the parameters in the damask documentation:
+    https://damask-multiphysics.org/documentation/file_formats/grid_solver.html#load-case
     """
     result = {
         "boundary_conditions": {"mechanical": {}},

--- a/pyiron_continuum/toolkit.py
+++ b/pyiron_continuum/toolkit.py
@@ -74,6 +74,47 @@ class DAMASK:
         """
         return DAMASKCreator.loading(solver=solver, load_steps=load_steps)
 
+
+    @staticmethod
+    def generate_loading_tensor(default="F"):
+        return DAMASKCreator.generate_loading_tensor(default=default)
+
+    generate_loading_tensor.__doc__ = DAMASKCreator.generate_loading_tensor.__doc__
+
+    @staticmethod
+    def loading_tensor_to_dict(key, value):
+        return DAMASKCreator.loading_tensor_to_dict(key, value)
+
+    loading_tensor_to_dict.__doc__ = DAMASKCreator.loading_tensor_to_dict.__doc__
+
+    @staticmethod
+    def generate_load_step(
+        N,
+        t,
+        F=None,
+        dot_F=None,
+        P=None,
+        dot_P=None,
+        f_out=None,
+        r=None,
+        f_restart=None,
+        estimate_rate=None,
+    ):
+        return DAMASKCreator.generate_load_step(
+            N=N,
+            t=t,
+            F=F,
+            dot_F=dot_F,
+            P=P,
+            dot_P=dot_P,
+            f_out=f_out,
+            r=r,
+            f_restart=f_restart,
+            estimate_rate=estimate_rate,
+        )
+
+    generate_load_step.__doc__ = DAMASKCreator.generate_load_step.__doc__
+
     @staticmethod
     def Material(rotation, elements, phase, homogenization):
         """

--- a/tests/integration/damask/test_latest.py
+++ b/tests/integration/damask/test_latest.py
@@ -1,7 +1,6 @@
 import unittest
 from pyiron_continuum import Project
 import os
-from damask import Rotation
 
 
 class TestDamask(unittest.TestCase):
@@ -19,36 +18,40 @@ class TestDamask(unittest.TestCase):
         job = self.project.create.job.DAMASK("damask_job")
         grains=8
         grids=16 # defines the number of grains and grids
-        homogenization = pr.continuum.damask.Homogenization()
-        elasticity_list = pr.continuum.damask.list_elasticity()
-        elasticity = pr.continuum.damask.Elasticity(**elasticity_list["Hooke_Al"])
-        plasticity_list = pr.continuum.damask.list_plasticity()
-        plasticity = pr.continuum.damask.Plasticity(
+        homogenization = self.project.continuum.damask.Homogenization()
+        elasticity_list = self.project.continuum.damask.list_elasticity()
+        elasticity = self.project.continuum.damask.Elasticity(
+            **elasticity_list["Hooke_Al"]
+        )
+        plasticity_list = self.project.continuum.damask.list_plasticity()
+        plasticity = self.project.continuum.damask.Plasticity(
             **plasticity_list["phenopowerlaw_Al"]
         )
-        phase = pr.continuum.damask.Phase(
+        phase = self.project.continuum.damask.Phase(
             composition='Aluminum', elasticity=elasticity, plasticity=plasticity
         )
-        rotation = pr.continuum.damask.Rotation(shape=grains)
-        material = pr.continuum.damask.Material(
+        rotation = self.project.continuum.damask.Rotation(shape=grains)
+        material = self.project.continuum.damask.Material(
             [rotation],['Aluminum'], phase, homogenization
         )
         job.material = material
-        grid = pr.continuum.damask.Grid.via_voronoi_tessellation(
+        grid = self.project.continuum.damask.Grid.via_voronoi_tessellation(
             box_size=1.0e-5, spatial_discretization=grids, num_grains=grains
         )
         job.grid = grid
-        key, value = pr.continuum.damask.generate_loading_tensor("dot_F")
+        key, value = self.project.continuum.damask.generate_loading_tensor("dot_F")
         value[0, 0] = 1e-3
         key[1, 1] = "P"
         key[2, 2] = "P"
-        data = pr.continuum.damask.loading_tensor_to_dict(key, value)
+        data = self.project.continuum.damask.loading_tensor_to_dict(key, value)
         load_step = [
-            pr.continuum.damask.generate_load_step(N=40, t=10, f_out=4, **data),
-            pr.continuum.damask.generate_load_step(N=60, t=60, f_out=4, **data),
+            self.project.continuum.damask.generate_load_step(N=40, t=10, f_out=4, **data),
+            self.project.continuum.damask.generate_load_step(N=60, t=60, f_out=4, **data),
         ]
         solver = job.list_solvers()[0]
-        job.loading = pr.continuum.damask.Loading(solver=solver, load_steps=load_step)
+        job.loading = self.project.continuum.damask.Loading(
+            solver=solver, load_steps=load_step
+        )
         job.run()
         self.assertEqual(job.output.stress.shape[1:], (3, 3))
 

--- a/tests/integration/damask/test_latest.py
+++ b/tests/integration/damask/test_latest.py
@@ -1,0 +1,57 @@
+import unittest
+from pyiron_continuum import Project
+import os
+from damask import Rotation
+
+
+class TestDamask(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.file_location = os.path.dirname(os.path.abspath(__file__))
+        cls.project = Project("DAMASK_LATEST")
+        cls.project.remove_jobs(recursive=True, silently=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.remove(enable=True)
+
+    def test_damask_tutorial(self):
+        job = self.project.create.job.DAMASK("damask_job")
+        grains=8
+        grids=16 # defines the number of grains and grids
+        homogenization = pr.continuum.damask.Homogenization()
+        elasticity_list = pr.continuum.damask.list_elasticity()
+        elasticity = pr.continuum.damask.Elasticity(**elasticity_list["Hooke_Al"])
+        plasticity_list = pr.continuum.damask.list_plasticity()
+        plasticity = pr.continuum.damask.Plasticity(
+            **plasticity_list["phenopowerlaw_Al"]
+        )
+        phase = pr.continuum.damask.Phase(
+            composition='Aluminum', elasticity=elasticity, plasticity=plasticity
+        )
+        rotation = pr.continuum.damask.Rotation(shape=grains)
+        material = pr.continuum.damask.Material(
+            [rotation],['Aluminum'], phase, homogenization
+        )
+        job.material = material
+        grid = pr.continuum.damask.Grid.via_voronoi_tessellation(
+            box_size=1.0e-5, spatial_discretization=grids, num_grains=grains
+        )
+        job.grid = grid
+        key, value = pr.continuum.damask.generate_loading_tensor("dot_F")
+        value[0, 0] = 1e-3
+        key[1, 1] = "P"
+        key[2, 2] = "P"
+        data = pr.continuum.damask.loading_tensor_to_dict(key, value)
+        load_step = [
+            pr.continuum.damask.generate_load_step(N=40, t=10, f_out=4, **data),
+            pr.continuum.damask.generate_load_step(N=60, t=60, f_out=4, **data),
+        ]
+        solver = job.list_solvers()[0]
+        job.loading = pr.continuum.damask.Loading(solver=solver, load_steps=load_step)
+        job.run()
+        self.assertEqual(job.output.stress.shape[1:], (3, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/damask/test_factory.py
+++ b/tests/unit/damask/test_factory.py
@@ -1,0 +1,29 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import unittest
+from pyiron_continuum.damask import factory
+
+
+class TestDamaskFactory(unittest.TestCase):
+    def test_generate_load_step(self):
+        key, value = factory.generate_loading_tensor()
+        value[0, 0] = 0
+        key[0, 0] = "P"
+        data = factory.generate_load_step(
+            boundary_conditions=(key, value), N=40, t=10
+        )
+        self.assertTrue("P" in data["boundary_conditions"]["mechanical"])
+        for tag in ["f_out", "r", "f_restart", "estimate_rate"]:
+            data = factory.generate_load_step(
+                boundary_conditions=(key, value), N=40, t=10, **{tag: 1}
+            )
+            if tag != "r":
+                self.assertTrue(tag in data)
+            else:
+                self.assertTrue(tag in data["discretization"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/damask/test_factory.py
+++ b/tests/unit/damask/test_factory.py
@@ -8,17 +8,20 @@ from pyiron_continuum.damask import factory
 
 class TestDamaskFactory(unittest.TestCase):
     def test_generate_load_step(self):
+        key, value = factory.generate_loading_tensor(default="P")
+        self.assertTrue(key[0, 0] == "P")
         key, value = factory.generate_loading_tensor()
         value[0, 0] = 0
         key[0, 0] = "P"
-        data = factory.generate_load_step(
-            boundary_conditions=(key, value), N=40, t=10
-        )
+        key[1, 1] = "dot_P"
+        key[2, 2] = "dot_F"
+        d = factory.loading_tensor_to_dict(key, value)
+        data = factory.generate_load_step(N=40, t=10, **d)
         self.assertTrue("P" in data["boundary_conditions"]["mechanical"])
         for tag in ["f_out", "r", "f_restart", "estimate_rate"]:
-            data = factory.generate_load_step(
-                boundary_conditions=(key, value), N=40, t=10, **{tag: 1}
-            )
+            d = factory.loading_tensor_to_dict(key, value)
+            d.update({tag: 1})
+            data = factory.generate_load_step(N=40, t=10, **d)
             if tag != "r":
                 self.assertTrue(tag in data)
             else:


### PR DESCRIPTION
As a final step for the series of Damask abstraction, I'm tackling the loading. Now I implemented an algorithm for the generation of deformation tensor. The definition of `load_step` is the same in the following:

Before:
```python

load_step =[{'mech_bc_dict':{'dot_F':[1e-3,0,0, 0,'x',0,  0,0,'x'],
                            'P':['x','x','x', 'x',0,'x',  'x','x',0]},
            'discretization':{'t': 10.,'N': 40},
            'additional': {'f_out': 4}
           },{'mech_bc_dict':{'dot_F':[1e-3,0,0, 0,'x',0,  0,0,'x'],
                              'P':['x','x','x', 'x',0,'x',  'x','x',0]},
            'discretization':{'t': 60.,'N': 60},
            'additional': {'f_out': 4}
           }]
```

Now:
```python
key, value = pr.continuum.damask.generate_loading_tensor("dot_F")
value[0, 0] = 1e-3
key[1, 1] = "P"
key[2, 2] = "P"
data = pr.continuum.damask.loading_tensor_to_dict(key, value)
load_step = [
    pr.continuum.damask.generate_load_step(N=40, t=10, f_out=4, **data),
    pr.continuum.damask.generate_load_step(N=60, t=60, f_out=4, **data),
]
```

Not only the syntax is (at least in my opinion) better, but also each step is assisted by doc strings.